### PR TITLE
Bound event

### DIFF
--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -21,7 +21,7 @@ fn main() {
                 response.set_from(None);
                 (Some(response), false)
             }
-            xmpp::Event::Bound => {
+            xmpp::Event::Bound(_jid) => {
                 (None, true)
             }
             _ => continue

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,6 +1,6 @@
 extern crate xmpp;
 use xmpp::XmppStream;
-use xmpp::stanzas::Stanza;
+use xmpp::stanzas::{Stanza, Presence, PresenceType};
 
 fn main() {
     let mut stream = XmppStream::new("alice", "localhost", "test");
@@ -12,17 +12,26 @@ fn main() {
         }
     }
     loop {
-        let response = match stream.handle() {
+        let (opt_response, send_presence) = match stream.handle() {
             xmpp::Event::StreamClosed => break,
             xmpp::Event::Message(msg) => {
                 let mut response = msg.clone();
                 let to = response.from().map(|x| x.into());
                 response.set_to(to);
                 response.set_from(None);
-                response
+                (Some(response), false)
+            }
+            xmpp::Event::Bound => {
+                (None, true)
             }
             _ => continue
         };
-        stream.send(response);
+        match opt_response {
+            Some(response) => stream.send(response).unwrap(),
+            None => ()
+        }
+        if send_presence {
+            stream.send(Presence::new(PresenceType::Available, "".to_owned())).unwrap();
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,8 @@ pub enum Event<'a> {
     IqResponse(stanzas::Iq),
     Message(stanzas::Message),
     Presence(stanzas::Presence),
-    Bound,
+    /// field 1: client JID
+    Bound(Option<String>),
     BindError(stanzas::Iq),
     StreamError(xml::Element),
     StreamClosed
@@ -186,7 +187,7 @@ impl XmppStream {
                                             if handler.pending_bind_id.as_ref()
                                             .map(|x| &x[..]) == iq.id() => {
                                                 handler.pending_bind_id = None;
-                                                return Event::Bound
+                                                return Event::Bound(iq.get_xmpp_bind_jid())
                                             },
                                         Some(IqType::Error)
                                             if handler.pending_bind_id.as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,8 +183,7 @@ impl XmppStream {
                                         None => continue,
                                         Some(IqType::Result)
                                             if handler.pending_bind_id.as_ref()
-                                                .map(|pending_bind_id| iq.id().unwrap_or("") == pending_bind_id)
-                                                .unwrap_or(false) =>
+                                                .map(|x| &x[..]) == iq.id() =>
                                             return Event::Bound,
                                         Some(IqType::Result)
                                         | Some(IqType::Error) => return Event::IqResponse(iq),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@ pub enum Event<'a> {
     Message(stanzas::Message),
     Presence(stanzas::Presence),
     Bound,
+    BindError(stanzas::Iq),
     StreamError(xml::Element),
     StreamClosed
 }
@@ -185,6 +186,10 @@ impl XmppStream {
                                             if handler.pending_bind_id.as_ref()
                                                 .map(|x| &x[..]) == iq.id() =>
                                             return Event::Bound,
+                                        Some(IqType::Error)
+                                            if handler.pending_bind_id.as_ref()
+                                                .map(|x| &x[..]) == iq.id() =>
+                                            return Event::BindError(iq),
                                         Some(IqType::Result)
                                         | Some(IqType::Error) => return Event::IqResponse(iq),
                                         Some(IqType::Set)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,12 +184,16 @@ impl XmppStream {
                                         None => continue,
                                         Some(IqType::Result)
                                             if handler.pending_bind_id.as_ref()
-                                                .map(|x| &x[..]) == iq.id() =>
-                                            return Event::Bound,
+                                            .map(|x| &x[..]) == iq.id() => {
+                                                handler.pending_bind_id = None;
+                                                return Event::Bound
+                                            },
                                         Some(IqType::Error)
                                             if handler.pending_bind_id.as_ref()
-                                                .map(|x| &x[..]) == iq.id() =>
-                                            return Event::BindError(iq),
+                                            .map(|x| &x[..]) == iq.id() => {
+                                                handler.pending_bind_id = None;
+                                                return Event::BindError(iq)
+                                            },
                                         Some(IqType::Result)
                                         | Some(IqType::Error) => return Event::IqResponse(iq),
                                         Some(IqType::Set)

--- a/src/stanzas/iq.rs
+++ b/src/stanzas/iq.rs
@@ -51,4 +51,12 @@ impl Iq {
                                          ("id".into(), None, id)])
         }
     }
+
+    pub fn get_xmpp_bind_jid(&self) -> Option<String> {
+        let ns = Some(ns::FEATURE_BIND);
+        self.elem
+            .get_child("bind", ns)
+            .and_then(|bind| bind.get_child("jid", ns))
+            .map(|jid| jid.content_str())
+    }
 }


### PR DESCRIPTION
Use-case is illustrated by the extended echo example: the event allows to send presence at the right time. That is once the session has been bound.

There could be an error case which could be handled either by extending `Event::Bound` with some kind of `Result`, leaving it with `Event::IqResponse`, or by introducing a new value such as `Event::BindError`. What's your preference?

In the example I would have liked to send the response/presence within the `match` block but `stream` is already mutably borrowed by `stream.handle()`.
